### PR TITLE
Actualiza instrucciones para usar Git y `geci-testmake`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 # Enlista phonies
 .PHONY: install requirements tests
 
-# "Hola Mundo" para `testMake`:
-hola-mundo:
-	curl --output hola-mundo --user $${BITBUCKET_USERNAME}:$${BITBUCKET_PASSWORD} https://bitbucket.org/IslasGECI/misctools/raw/7dc5d6152cbb/txt/hola-mundo.txt
-	if [ -s hola-mundo ]; then cat hola-mundo; else echo; echo "No pude conectarme a Bitbucket"; echo "¿Tienes las variables 'BITBUCKET_USERNAME' y 'BITBUCKET_PASSWORD' en tu entorno?"; echo; exit 1; fi
-
 # Instala estas herramientas miscelaneas
 install:
 	# Copia ejecutables

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Conjunto de herramientas pequeñas y prototipos del equipo de Ciencia de Datos -
 ## Instalación
 
 ```bash
-hg clone https://bitbucket.org/IslasGECI/misctools
+git clone https://github.com/IslasGECI/misctools.git
 cd misctools
-make install
+sudo make install
 ```
 
-## Configuración del `testMake` para Ubuntu 18.04 (Bionic Beaver)
+## Configuración del `geci-testmake` para Ubuntu 18.04 (Bionic Beaver)
 
 Exporta tus credenciales de Bitbucket como variables de entorno:
 
@@ -35,7 +35,7 @@ Verifica que tienes Docker instalado:
 docker --version
 ```
 
-Para correr Docker sin `sudo` (_Got permission denied..._) agrega tu usuario al grupo `docker`:
+Para correr Docker sin `sudo` (y evitar el mensaje: _Got permission denied..._) agrega tu usuario al grupo `docker`:
 
 ```bash
 sudo usermod -aG docker $USER
@@ -61,8 +61,8 @@ Si no tienes cURL instálalo con:
 sudo apt install curl
 ```
 
-Corre el `testMake`:
+Corre el `geci-testmake`:
 
 ```bash
-testMake misctools hola-mundo
+geci-testmake misctools hola-mundo
 ```

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ sudo apt install curl
 Corre el `geci-testmake`:
 
 ```bash
-geci-testmake misctools hola-mundo
+geci-testmake hola mundo
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 Conjunto de herramientas pequeñas y prototipos del equipo de Ciencia de Datos - GECI.
 
-## Instalación
+Aquí describo cómo instalar `misctools` y cómo configurar `geci-testmake` en Linux Mint 19.2 (Tina) y en Ubuntu 18.04 (Bionic Beaver).
+
+## Prerequisitos
+
+En Linux Mint, primero deberás instalar Git; en Ubuntu, Git ya viene instalado.
+
+Verifica si tienes Git instalado:
+
+```bash
+git --version
+```
+
+Si no tienes Git instálalo con:
+
+```bash
+sudo apt install git
+```
+
+## Instalación de misctools
 
 ```bash
 git clone https://github.com/IslasGECI/misctools.git
@@ -10,7 +28,7 @@ cd misctools
 sudo make install
 ```
 
-## Configuración del `geci-testmake` para Ubuntu 18.04 (Bionic Beaver)
+## Configuración de `geci-testmake`
 
 Exporta tus credenciales de Bitbucket como variables de entorno:
 
@@ -41,7 +59,7 @@ Para correr Docker sin `sudo` (y evitar el mensaje: _Got permission denied..._) 
 sudo usermod -aG docker $USER
 ```
 
-Haz _log out_ de Ubuntu y luego _log in_ nuevamente para que el sistema re-evalue tu pertenencia al grupo.
+En Ubuntu haz _log out_ y luego _log in_ para que el sistema re-evalue tu pertenencia al grupo. En Linux Mint deberás reiniciar la máquina ya que hacer _log out_ y _log in_ no es suficiente.
 
 Verifica que puedes correr Docker sin `sudo`:
 
@@ -61,7 +79,7 @@ Si no tienes cURL instálalo con:
 sudo apt install curl
 ```
 
-Corre el `geci-testmake`:
+Finalmente, corre `geci-testmake`:
 
 ```bash
 geci-testmake hola mundo

--- a/txt/hola-mundo.txt
+++ b/txt/hola-mundo.txt
@@ -1,5 +1,0 @@
-
-
-¡Hola de parte de Ciencia de Datos - GECI!
-Este mensaje muestra que tu instalación de 'testMake' parece estar funcionando correctamente.
-


### PR DESCRIPTION
En lugar de Mercurial y `testMake` ahora usamos Git y `geci-testmake`