### PR TITLE
Permite el uso de Docker anidado

### DIFF
--- a/src/geci-testmake
+++ b/src/geci-testmake
@@ -131,6 +131,7 @@ if [ -f $RUTA_CLON/.git_checkout_succeeded ]; then
     --env BITBUCKET_USERNAME=$BITBUCKET_USERNAME \
     --name $CONTENEDOR \
     --rm \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume $RUTA_CLON:/workdir \
     $IMAGEN bash -c "\
       umask 000; \


### PR DESCRIPTION
Para poder generar en `gatos_guadalupe_segunda_mitad` los resultados de `gatos_guadalupe_primera_mitad`, es necesario el uso de Docker anidado. Este _PR_ permite que `geci-testmake` use Docker anidado.

---

[GECI-25: Clonar el repo de `gatos_guadalupe` en los repos `gatos_guadalupe_segunda_mitad` y `gatos_guadalupe_primera_mitad`](https://app.gitkraken.com/glo/card/00599cc0c2d74fc9866f73a523c03388)